### PR TITLE
feat: typed combineReducers function

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:commonjs": "rm -rf es5-commonjs/ && tsc -p . --outDir es5-commonjs/",
     "build:module": "rm -rf es5-module/ && tsc -p . --outDir es5-module/ -m 'ES2015'",
     "build:jsnext": "rm -rf jsnext/ && tsc -p . --outDir jsnext/ -t 'ES2015'",
-    "lint": "tslint --project './tsconfig.json'",
+    "lint": "tslint --project .",
     "pretest": "tsc -p ./tsconfig.spec.json --noEmit",
     "test": "jest --config jest.config.json ./src",
     "test:watch": "jest --config jest.config.json ./src --watch",

--- a/src/combine-reducers.spec.ts
+++ b/src/combine-reducers.spec.ts
@@ -1,0 +1,49 @@
+import { combineReducers, createAction, getType } from '.';
+
+type State = { a: number; b: string };
+
+type Actions = { type: 'A'; payload: number } | { type: 'B'; payload: string };
+
+const actions = {
+  actionA: createAction('A', (val: number) => ({ type: 'A', payload: val })),
+  actionB: createAction('B', (val: string) => ({ type: 'B', payload: val })),
+};
+
+const handleA = (state = 0, action: Actions) => {
+  switch (action.type) {
+    case getType(actions.actionA):
+      return state + action.payload;
+    default:
+      return state;
+  }
+};
+
+const handleB = (state = '', action: Actions) => {
+  switch (action.type) {
+    case getType(actions.actionB):
+      return state + action.payload;
+    default:
+      return state;
+  }
+};
+
+describe('combineReducers', () => {
+  it('it works ;o)', () => {
+    const handle = combineReducers<State, Actions>({
+      a: handleA,
+      b: handleB,
+    });
+
+    let s: State = { a: 1, b: '' };
+
+    s = handle(s, actions.actionA(4));
+
+    expect(s.a).toBe(5);
+    expect(s.b).toBe('');
+
+    s = handle(s, actions.actionB('fred'));
+
+    expect(s.a).toBe(5);
+    expect(s.b).toBe('fred');
+  });
+});

--- a/src/combine-reducers.ts
+++ b/src/combine-reducers.ts
@@ -1,0 +1,25 @@
+import { combineReducers as reduxCombineReducers } from 'redux';
+
+/**
+ * A *reducer* function.
+ *
+ * Same as *Reducer<S>* from 'redux', except with typed action.
+ */
+export type Reducer<S, A> = (state: S, action: A) => S;
+
+/**
+ * Object whose values correspond to different reducer functions.
+ *
+ * Same as *ReducersMapObject<S>* from 'redux', except with typed action.
+ */
+export type ReducersMapObject<S, A> = { [P in keyof S]?: Reducer<S[P], A> };
+
+/**
+ * @description turns an object whose values are different reducer functions, into a single
+ * reducer function.
+ *
+ * Same as *combineReducers<S>* from 'redux', except with typed action.
+ */
+export function combineReducers<S, A>(reducers: ReducersMapObject<S, A>): Reducer<S, A> {
+  return reduxCombineReducers(reducers as any) as any;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './redux-types';
 export * from './get-type';
 export * from './is-action-of';
 export * from './create-action';
+export * from './combine-reducers';


### PR DESCRIPTION
added typed version of `combineReducers` method from 'redux', usage is the same as original method, except mine has two **required** generics type parameters - state type and actions type

usage:
```ts
// same old story ...
import { createAction, combineReducers } from "typesafe-actions";
import { $call } from "utility-types";

const actions = {
  actionA: createAction("A", (val: string) => ({ type: "A", payload: val })),
  actionB: createAction("B", (val: number) => ({ type: "B", payload: val })),
};

const returnsOfActions = Object.values(actions).map($call);
type Actions = typeof returnsOfActions[number];

function reducerA(state: string, action: Actions): string { ... }
function reducerB(state: number, action: Actions): number { ... }

type State: { a: string, b: number };

// verbose way:
const reducer = (state: State, action: Actions) => {
  return {
    a: reducerA(state.a, action),
    b: reducerB(state.b, action),
  };
};

// 'redux' way:
const reducer = combineReducers<State, Actions>({
  a: reducerA,
  b: reducerB,
});
```
---
original method throws this error (reason for this PR):
```
message: 'Argument of type '{ a: (state: number | undefined, action: { type: "A"; payload: string; } | { type: "B"; payload: ...' is not assignable to parameter of type 'ReducersMapObject'.
  Property 'a' is incompatible with index signature.
    Type '(state: number | undefined, action: { type: "A"; payload: string; } | { type: "B"; payload: strin...' is not assignable to type 'Reducer<any>'.
      Types of parameters 'action' and 'action' are incompatible.
        Type 'AnyAction' is not assignable to type '{ type: "A"; payload: string; } | { type: "B"; payload: string; }'.
          Type 'AnyAction' is not assignable to type '{ type: "B"; payload: string; }'.
            Property 'payload' is missing in type 'AnyAction'.'
```

---
PS: edit in package.json is required on my machine (tslint fails otherwise)
