### PR TITLE
docs(readme): fix api example import of create standard action

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ Examples:
 [> Advanced Usage Examples](src/create-standard-action.spec.ts)
 
 ```ts
-import { createAction } from 'typesafe-actions';
+import { createStandardAction } from 'typesafe-actions';
 
 // type only
 const increment = createStandardAction('INCREMENT')<void>();


### PR DESCRIPTION
👋  just wanted to update the readme quickly when I saw a small mistake in the import name. 