### PR TITLE
Ensure docs reflect base action not working with helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,10 +577,11 @@ expect(failureResult).toEqual({
 > contains properly narrowed literal type
 
 
-**Warning**: This does not work for the [action](#action) actionCreator
+**NOTE**: ActionCreator type is generated from the `createAction` API. Simple [action](#action) creators throw a `RuntimeError`
+
 
 ```ts
-function getType(actionCreator: (...args) => T): T
+function getType(actionCreator: ActionCreator<T>): T
 ```
 
 [> Advanced Usage Examples](src/get-type.spec.ts)
@@ -612,7 +613,7 @@ switch (action.type) {
 > it will narrow actions union to a specific action
 
 
-**Warning**: This does not work for the [action](#action) actionCreator
+**NOTE**: ActionCreator type is generated from the `createAction` API. Simple [action](#action) creators throw a `RuntimeError`
 
 ```ts
 // can be used as a binary function

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ export type RootState = StateType<typeof rootReducer>;
 
 > simple action factory function, to create typed action
 
+**Warning**: this action creator does not let you use action helpers such as `getType` and `isActionOf`
+
 ```ts
 function action(type: T, payload?: P, meta?: M): { type: T, payload?: P, meta?: M }
 ```
@@ -574,6 +576,9 @@ expect(failureResult).toEqual({
 > get the "type" property of a given action-creator  
 > contains properly narrowed literal type
 
+
+**Warning**: This does not work for the [action](#action) actionCreator
+
 ```ts
 function getType(actionCreator: (...args) => T): T
 ```
@@ -605,6 +610,9 @@ switch (action.type) {
 
 > (curried assert function) check if action is an instance of given action-creator(s)
 > it will narrow actions union to a specific action
+
+
+**Warning**: This does not work for the [action](#action) actionCreator
 
 ```ts
 // can be used as a binary function


### PR DESCRIPTION
This fixes #80 and #83 as they aren't code issues, but documentation issues. There is a case to determine whether the `action` actionCreator should work with the action helpers.
I suggest that this is probably something that should be added, or the `action` actionCreator removed from this library as it has proved a point of confusion for a fair few people.