### PR TITLE
Handle array of types in isOfType

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,10 @@ if(isActionOf(addTodo, action)) {
 isOfType(type: T, action: any): action is Action<T>
 // or curried function
 isOfType(type: T): (action: any) => action is T
+// it also accepts an array of types to check against
+isOfType(type: T[], action: any): action is Action<T>
+// and also works as curried function
+isOfType(type: T[]): (action: any) => action is T
 ```
 
 Examples:
@@ -685,6 +689,17 @@ const addTodoToast: Epic<RootAction, RootState, Services> =
       toastService.success(`Added new todo: ${action.payload}`);
     })
     .ignoreElements();
+// Filter against array of actions
+import { ADD, REMOVE } from './todos-types';
+
+const addOrRemove: Epic<RootAction, RootState, Services> =
+  (action$, store, { toastService }) => action$
+    .filter(isOfType([ADD, REMOVE]))
+    .do((action) => {
+      // action is narrowed as: { type: "todos/ADD"; payload: Todo; } | { type: "todos/REMOVE"; payload: Todo; }
+      toastService.update(action.payload);
+    })
+    .ignoreElements();
 
 // conditionals where you need a type guard
 import { ADD } from './todos-types';
@@ -692,6 +707,12 @@ import { ADD } from './todos-types';
 if(isOfType(ADD, action)) {
   return functionThatAcceptsTodo(action.payload) // action: { type: "todos/ADD"; payload: Todo; }
 }
+// or
+
+if(isOfType([ADD, REMOVE], action)) {
+  return functionThatAcceptsTodo(action.payload) // action:  { type: "todos/ADD"; payload: Todo; } | { type: "todos/REMOVE"; payload: Todo; }
+}
+
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/src/is-of-type.spec.ts
+++ b/src/is-of-type.spec.ts
@@ -12,7 +12,7 @@ const {
 const typeOnlyAction = withTypeOnly();
 const typeOnlyExpected = { type: 'WITH_TYPE_ONLY' };
 const payloadAction = withPayload(2);
-// const payloadExpected = { type: 'WITH_PAYLOAD', payload: 2 };
+const payloadExpected = { type: 'WITH_PAYLOAD', payload: 2 };
 const payloadMetaAction = withPayloadMeta(2, 'metaValue');
 // const payloadMetaExpected = {
 //   type: 'WITH_PAYLOAD_META',
@@ -61,5 +61,29 @@ describe('isOfType', () => {
     );
     expect(actual).toHaveLength(1);
     expect(actual).toEqual([typeOnlyExpected]);
+  });
+
+  it('should correctly assert for array of action types and action', () => {
+    expect(
+      isOfType(
+        [types.WITH_MAPPED_PAYLOAD, types.WITH_TYPE_ONLY],
+        typeOnlyAction
+      )
+    ).toBeTruthy();
+    expect(
+      isOfType([types.WITH_MAPPED_PAYLOAD, types.WITH_TYPE_ONLY])(
+        typeOnlyAction
+      )
+    ).toBeTruthy();
+    expect(isOfType([types.WITH_PAYLOAD], typeOnlyAction)).toBeFalsy();
+    expect(isOfType([types.WITH_PAYLOAD])(typeOnlyAction)).toBeFalsy();
+  });
+
+  it('should correctly assert for an array of action types', () => {
+    const actual: Array<
+      { type: 'WITH_TYPE_ONLY' } | { type: 'WITH_PAYLOAD'; payload: number }
+    > = $action.filter(isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD]));
+    expect(actual).toHaveLength(2);
+    expect(actual).toEqual([typeOnlyExpected, payloadExpected]);
   });
 });

--- a/src/is-of-type.ts
+++ b/src/is-of-type.ts
@@ -1,4 +1,4 @@
-import { StringType } from './types';
+import { StringType, Unboxed } from './types';
 import { validateActionType } from './utils';
 /**
  * @description (curried assert function) check if action type is equal given type-constant
@@ -13,20 +13,44 @@ export function isOfType<T extends StringType, A extends { type: StringType }>(
  * @description (curried assert function) check if action type is equal given type-constant
  * @description it works with discriminated union types
  */
+export function isOfType<
+  T extends K[],
+  K extends StringType,
+  A extends { type: StringType }
+>(type: T, action: A): action is A extends { type: Unboxed<T> } ? A : never;
+
+/**
+ * @description (curried assert function) check if action type is equal given type-constant
+ * @description it works with discriminated union types
+ */
 export function isOfType<T extends StringType>(
   type: T
 ): <A extends { type: StringType }>(
   action: A
 ) => action is A extends { type: T } ? A : never;
 
-/** implementation */
-export function isOfType<T extends StringType, A extends { type: StringType }>(
-  actionType: T,
-  actionOrNil?: A
-) {
-  validateActionType(actionType);
+/**
+ * @description (curried assert function) check if action type is equal given type-constant
+ * @description it works with discriminated union types
+ */
+export function isOfType<T extends K[], K extends StringType>(
+  type: T
+): <A extends { type: StringType }>(
+  action: A
+) => action is A extends { type: Unboxed<T> } ? A : never;
 
-  const assertFn = (action: A) => action.type === actionType;
+/** implementation */
+export function isOfType<
+  T extends StringType | StringType[],
+  A extends { type: StringType }
+>(actionType: T, actionOrNil?: A) {
+  Array.isArray(actionType)
+    ? actionType.forEach(type => validateActionType(type))
+    : validateActionType(actionType);
+
+  const assertFn = Array.isArray(actionType)
+    ? (action: A) => actionType.includes(action.type)
+    : (action: A) => action.type === actionType;
 
   // with 1 arg return assertFn
   if (actionOrNil == null) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,3 +134,10 @@ export type StateType<ReducerOrMap> = ReducerOrMap extends (
   : ReducerOrMap extends object
     ? { [K in keyof ReducerOrMap]: StateType<ReducerOrMap[K]> }
     : never;
+
+/**
+ * @desc Unboxes array | Tuple | Promise to it's inner type
+ */
+export type Unboxed<T> = T extends Array<infer Y>
+  ? Y
+  : T extends Promise<infer V> ? V : T;


### PR DESCRIPTION
It is PR implementing new API proposed in issue #85. API of `isOfType` has been extended to accept also an array of types as `redux-observable` operator `ofType`. It does not introduce any baking changes.

* [x] Rebase before creating a PR to keep commit history clean
* [x] Clear node_modules and reinstall all the dependencies: `npm run reinstall`
* [x] Run checker npm script: `npm run check`

Extra checklist:
* [x] Always add some description and refer to all the related issues using `#` tag

For bugfixes:
 * [ ] Add at least one unit test to cover the bug that have been fixed

For new feature:
 * [x] Update API docs
 * [x] Add examples to demonstrate new feature
 * [x] Add type unit tests
 * [x] Add runtime unit tests
