### PR TITLE
Additional overloads to avoid ambiguous isActionOf type resolution for #63

### DIFF
--- a/src/is-action-of.spec.ts
+++ b/src/is-action-of.spec.ts
@@ -160,7 +160,7 @@ describe('isActionOf', () => {
   });
 
   it('should correctly resolve assertions', () => {
-    const action = withMappedPayload(1234);
+    const action: any = withMappedPayload(1234);
     if (isActionOf([withMappedPayload, withMappedPayloadMeta], action)) {
       expect(action.payload).toBe(1234);
     } else {

--- a/src/is-action-of.spec.ts
+++ b/src/is-action-of.spec.ts
@@ -158,4 +158,18 @@ describe('isActionOf', () => {
       mappedPayloadMetaExpected,
     ]);
   });
+
+  it('should correctly resolve assertions', () => {
+    const action = withMappedPayload(1234);
+    if (isActionOf([withMappedPayload, withMappedPayloadMeta], action)) {
+      expect(action.payload).toBe(1234);
+    } else {
+      fail('isActionOf assertion should work when not curried');
+    }
+    if (isActionOf([withMappedPayload, withMappedPayloadMeta])(action)) {
+      expect(action.payload).toBe(1234);
+    } else {
+      fail('isActionOf assertion should work when curried');
+    }
+  });
 });

--- a/src/is-action-of.ts
+++ b/src/is-action-of.ts
@@ -2,24 +2,43 @@ import { TypeMeta } from './types';
 
 export type AC<T extends { type: string }> = ((...args: any[]) => T) &
   TypeMeta<T['type']>;
-export type ACs<
-  T1 extends { type: string },
-  T2 extends { type: string } = any,
-  T3 extends { type: string } = any,
-  T4 extends { type: string } = any,
-  T5 extends { type: string } = any
-> =
-  | [AC<T1>]
-  | [AC<T1>, AC<T2>]
-  | [AC<T1>, AC<T2>, AC<T3>]
-  | [AC<T1>, AC<T2>, AC<T3>, AC<T4>]
-  | [AC<T1>, AC<T2>, AC<T3>, AC<T4>, AC<T5>];
 
 /**
  * @description (curried assert function) check if an action is the instance of given action-creator(s)
  * @description it works with discriminated union types
  * @inner If you need more than 5 arguments -> use switch
  */
+export function isActionOf<A extends { type: string }, T1 extends A>(
+  actionCreators: [AC<T1>],
+  action: { type: string }
+): action is [T1][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A
+>(
+  actionCreators: [AC<T1>, AC<T2>],
+  action: { type: string }
+): action is [T1, T2][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A,
+  T3 extends A
+>(
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>],
+  action: { type: string }
+): action is [T1, T2, T3][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A,
+  T3 extends A,
+  T4 extends A
+>(
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>, AC<T4>],
+  action: { type: string }
+): action is [T1, T2, T3, T4][number];
 export function isActionOf<
   A extends { type: string },
   T1 extends A,
@@ -28,12 +47,7 @@ export function isActionOf<
   T4 extends A,
   T5 extends A
 >(
-  actionCreators:
-    | ACs<T1>
-    | ACs<T1, T2>
-    | ACs<T1, T2, T3>
-    | ACs<T1, T2, T3, T4>
-    | ACs<T1, T2, T3, T4, T5>,
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>, AC<T4>, AC<T5>],
   action: { type: string }
 ): action is [T1, T2, T3, T4, T5][number];
 
@@ -51,6 +65,31 @@ export function isActionOf<A extends { type: string }, T1 extends A>(
  * @description it works with discriminated union types
  * @inner If you need more than 5 arguments -> use switch
  */
+export function isActionOf<A extends { type: string }, T1 extends A>(
+  actionCreators: [AC<T1>]
+): (action: A) => action is [T1][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A
+>(actionCreators: [AC<T1>, AC<T2>]): (action: A) => action is [T1, T2][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A,
+  T3 extends A
+>(
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>]
+): (action: A) => action is [T1, T2, T3][number];
+export function isActionOf<
+  A extends { type: string },
+  T1 extends A,
+  T2 extends A,
+  T3 extends A,
+  T4 extends A
+>(
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>, AC<T4>]
+): (action: A) => action is [T1, T2, T3, T4][number];
 export function isActionOf<
   A extends { type: string },
   T1 extends A,
@@ -59,12 +98,7 @@ export function isActionOf<
   T4 extends A,
   T5 extends A
 >(
-  actionCreators:
-    | ACs<T1>
-    | ACs<T1, T2>
-    | ACs<T1, T2, T3>
-    | ACs<T1, T2, T3, T4>
-    | ACs<T1, T2, T3, T4, T5>
+  actionCreators: [AC<T1>, AC<T2>, AC<T3>, AC<T4>, AC<T5>]
 ): (action: A) => action is [T1, T2, T3, T4, T5][number];
 
 /**
@@ -86,12 +120,11 @@ export function isActionOf<
 >(
   creatorOrCreators:
     | AC<T1>
-    | (
-        | ACs<T1>
-        | ACs<T1, T2>
-        | ACs<T1, T2, T3>
-        | ACs<T1, T2, T3, T4>
-        | ACs<T1, T2, T3, T4, T5>),
+    | [AC<T1>]
+    | [AC<T1>, AC<T2>]
+    | [AC<T1>, AC<T2>, AC<T3>]
+    | [AC<T1>, AC<T2>, AC<T3>, AC<T4>]
+    | [AC<T1>, AC<T2>, AC<T3>, AC<T4>, AC<T5>],
   actionOrNil?: A
 ) {
   if (creatorOrCreators == null) {


### PR DESCRIPTION
`isActionOf` when given an array doesn't yield the correct type assertions. Here's a minimalist example:

```typescript
const action1 = createAction('Action 1', resolve => (value: number) => resolve({ value }));
const action2 = createAction('Action 2', resolve => (value: number) => resolve({ value }));

const action: any = action1(1);
if (isActionOf([action1, action2], action)) {
  // This should be valid because `payload` exists on both action1 and action2 types but the actual resolution was before this change `action1 | action2 | {type: string}` and is now correctly `action1 | action2`
  console.log(action.payload.value);
}
```

Thank you for your contribution! :thumbsup:

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Rebase before creating a PR to keep commit history clean
* [x] Clear node_modules and reinstall all the dependencies: `npm run reinstall`
* [x] Run checker npm script: `npm run check`

Extra checklist:
* [x] Always add some description and refer to all the related issues using `#` tag

For bugfixes:
 * [x] Add at least one unit test to cover the bug that have been fixed

