### PR TITLE
Add toString function to action creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,12 @@ const getTodoStandardWithMap = createStandardAction('GET_TODO').map(
 );
 ```
 
+### Migrating from `redux-actions`
+
+If you're using `redux-actions`, its `createAction` can be replaced with any of the above styles. Usage of its `createActions` function will need to be replaced with individual usages of `createAction`. The resulting hash of actions does not provide inference for the individual values.
+
+Additionally, if you're migrating from JS -> TS, you can swap out action creators with `typesafe-actions` and use them with `handleActions` from `redux-actions` in JS. This is because the action creators exposed by `typesafe-actions` provide the `toString` method used by `redux-actions` to route actions to the correct reducer.
+
 [⇧ back to top](#table-of-contents)
 
 ---

--- a/src/create-action.spec.ts
+++ b/src/create-action.spec.ts
@@ -2,6 +2,14 @@ import { createAction } from './';
 import { types } from './test-utils';
 
 describe('createAction', () => {
+  it('toString', () => {
+    const action = createAction(types.WITH_TYPE_ONLY, resolve => {
+      return () => resolve();
+    });
+    expect(action.toString()).toBe('WITH_TYPE_ONLY');
+    expect((action as any) == 'WITH_TYPE_ONLY').toBe(true);
+  });
+
   it('with type only - shorthand', () => {
     const action = createAction(types.WITH_TYPE_ONLY);
     const actual: { type: 'WITH_TYPE_ONLY' } = action();

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -26,5 +26,7 @@ export function createAction<
 
   return Object.assign(actionCreator, {
     getType: () => actionType,
+    // redux-actions compatibility
+    toString: () => actionType,
   });
 }

--- a/src/create-standard-action.spec.ts
+++ b/src/create-standard-action.spec.ts
@@ -2,6 +2,13 @@ import { createStandardAction } from './create-standard-action';
 
 describe('createStandardAction', () => {
   describe('constructor', () => {
+    it('toString', () => {
+      const increment = createStandardAction('INCREMENT')();
+
+      expect(increment.toString()).toBe('INCREMENT');
+      expect((increment as any) == 'INCREMENT').toBe(true);
+    });
+
     it('with type only - shorthand', () => {
       const increment = createStandardAction('INCREMENT')();
       const action: { type: 'INCREMENT' } = increment();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,5 +24,9 @@ export function withType<T extends StringType, AC extends ActionCreator<T>>(
     constructorFunction != null
       ? constructorFunction(type)
       : ((() => ({ type })) as AC);
-  return Object.assign(actionCreator, { getType: () => type });
+  return Object.assign(actionCreator, {
+    getType: () => type,
+    // redux-actions compatibility
+    toString: () => type,
+  });
 }


### PR DESCRIPTION
This allows people migrating from redux-actions (and using `==` to coerce
those actions to stringst to check against `action.type`) to continue to do
so as part of an incremental transition.

---

Thank you for your contribution! :thumbsup:

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [X] Rebase before creating a PR to keep commit history clean
* [X] Clear node_modules and reinstall all the dependencies: `npm run reinstall`
* [X] Run checker npm script: `npm run check`

Extra checklist:
* [X] Always add some description and refer to all the related issues using `#` tag

For new feature:
 * [x] Update API docs
 * [ ] Add examples to demonstrate new feature
 * [ ] Add type unit tests
 * [x] Add runtime unit tests

Left out the above because my intention wasn't necessarily to introduce this as a usable API but
as a js -> ts migration path.