### PR TITLE
Fix cancel:never on test suite

### DIFF
--- a/src/__snapshots__/create-async-action.spec.ts.snap
+++ b/src/__snapshots__/create-async-action.spec.ts.snap
@@ -26,9 +26,9 @@ exports[`async action with cancel fetchUsersAsync.success([
       { firstName: 'Piotr', lastName: 'Witek' },
     ]) 1`] = `"T.PayloadAction<\\"FETCH_USERS_SUCCESS\\", User[]>"`;
 
-exports[`async action with cancel fn(fetchUsersAsync) 1`] = `"AsyncActionCreator<[\\"FETCH_USERS_REQUEST\\", undefined], [\\"FETCH_USERS_SUCCESS\\", User[]], [\\"FETCH_USERS_FAILURE\\", Error], [\\"FETCH_USERS_CANCEL\\", string], \\"FETCH_USERS_REQUEST\\", undefined, \\"FETCH_USERS_SUCCESS\\", User[], \\"FETCH_USERS_FAILURE\\", Error, \\"FETCH_USERS_CANCEL\\", string>"`;
+exports[`async action with cancel fn(fetchUsersAsync) 1`] = `"Pick<{ request: T.EmptyAC<\\"FETCH_USERS_REQUEST\\">; success: T.PayloadAC<\\"FETCH_USERS_SUCCESS\\", User[]>; failure: T.PayloadAC<\\"FETCH_USERS_FAILURE\\", Error>; cancel: T.PayloadAC<\\"FETCH_USERS_CANCEL\\", string>; }, \\"request\\" | \\"success\\" | \\"failure\\" | \\"cancel\\">"`;
 
-exports[`async action with undefined type fetchUsersAsync.cancel 1`] = `"never"`;
+exports[`async action with undefined type fetchUsersAsync.cancel 1`] = `"Property 'cancel' does not exist on type 'Pick<{ request: EmptyAC<\\"FETCH_USERS_REQUEST\\">; success: PayloadAC<\\"FETCH_USERS_SUCCESS\\", User[]>; failure: PayloadAC<\\"FETCH_USERS_FAILURE\\", Error>; cancel: never; }, \\"request\\" | \\"success\\" | \\"failure\\">'."`;
 
 exports[`async action with undefined type fetchUsersAsync.failure(
       Error('reason')
@@ -40,4 +40,4 @@ exports[`async action with undefined type fetchUsersAsync.success([
       { firstName: 'Piotr', lastName: 'Witek' },
     ]) 1`] = `"T.PayloadAction<\\"FETCH_USERS_SUCCESS\\", User[]>"`;
 
-exports[`async action with undefined type fn(fetchUsersAsync) 1`] = `"AsyncActionCreator<[\\"FETCH_USERS_REQUEST\\", undefined], [\\"FETCH_USERS_SUCCESS\\", User[]], [\\"FETCH_USERS_FAILURE\\", Error], never, \\"FETCH_USERS_REQUEST\\", undefined, \\"FETCH_USERS_SUCCESS\\", User[], \\"FETCH_USERS_FAILURE\\", Error, never, never>"`;
+exports[`async action with undefined type fn(fetchUsersAsync) 1`] = `"Pick<{ request: T.EmptyAC<\\"FETCH_USERS_REQUEST\\">; success: T.PayloadAC<\\"FETCH_USERS_SUCCESS\\", User[]>; failure: T.PayloadAC<\\"FETCH_USERS_FAILURE\\", Error>; cancel: never; }, \\"request\\" | \\"success\\" | \\"failure\\">"`;

--- a/src/create-async-action.spec.snap.ts
+++ b/src/create-async-action.spec.snap.ts
@@ -20,7 +20,7 @@ type User = { firstName: string; lastName: string };
       ['FETCH_USERS_FAILURE', Error]
     >
   ) => a;
-  // @dts-jest:pass:snap -> AsyncActionCreator<["FETCH_USERS_REQUEST", undefined], ["FETCH_USERS_SUCCESS", User[]], ["FETCH_USERS_FAILURE", Error], never, "FETCH_USERS_REQUEST", undefined, "FETCH_USERS_SUCCESS", User[], "FETCH_USERS_FAILURE", Error, never, never>
+  // @dts-jest:pass:snap -> Pick<{ request: T.EmptyAC<"FETCH_USERS_REQUEST">; success: T.PayloadAC<"FETCH_USERS_SUCCESS", User[]>; failure: T.PayloadAC<"FETCH_USERS_FAILURE", Error>; cancel: never; }, "request" | "success" | "failure">
   fn(fetchUsersAsync);
 
   // @dts-jest:pass:snap -> T.EmptyAction<"FETCH_USERS_REQUEST">
@@ -42,7 +42,7 @@ type User = { firstName: string; lastName: string };
     type: 'FETCH_USERS_FAILURE', payload: Error('reason')
   } */
 
-  // @dts-jest:pass:snap -> never
+  // @dts-jest:fail:snap -> Property 'cancel' does not exist on type 'Pick<{ request: EmptyAC<"FETCH_USERS_REQUEST">; success: PayloadAC<"FETCH_USERS_SUCCESS", User[]>; failure: PayloadAC<"FETCH_USERS_FAILURE", Error>; cancel: never; }, "request" | "success" | "failure">'.
   fetchUsersAsync.cancel;
 }
 
@@ -93,7 +93,7 @@ type User = { firstName: string; lastName: string };
       ['FETCH_USERS_CANCEL', string]
     >
   ) => a;
-  // @dts-jest:pass:snap -> AsyncActionCreator<["FETCH_USERS_REQUEST", undefined], ["FETCH_USERS_SUCCESS", User[]], ["FETCH_USERS_FAILURE", Error], ["FETCH_USERS_CANCEL", string], "FETCH_USERS_REQUEST", undefined, "FETCH_USERS_SUCCESS", User[], "FETCH_USERS_FAILURE", Error, "FETCH_USERS_CANCEL", string>
+  // @dts-jest:pass:snap -> Pick<{ request: T.EmptyAC<"FETCH_USERS_REQUEST">; success: T.PayloadAC<"FETCH_USERS_SUCCESS", User[]>; failure: T.PayloadAC<"FETCH_USERS_FAILURE", Error>; cancel: T.PayloadAC<"FETCH_USERS_CANCEL", string>; }, "request" | "success" | "failure" | "cancel">
   fn(fetchUsersAsync);
 
   // @dts-jest:pass:snap -> T.EmptyAction<"FETCH_USERS_REQUEST">

--- a/src/create-async-action.spec.ts
+++ b/src/create-async-action.spec.ts
@@ -42,7 +42,7 @@ type User = { firstName: string; lastName: string };
     type: 'FETCH_USERS_FAILURE', payload: Error('reason')
   } */
 
-  // @dts-jest:pass:snap
+  // @dts-jest:fail:snap
   fetchUsersAsync.cancel;
 }
 

--- a/src/create-async-action.ts
+++ b/src/create-async-action.ts
@@ -6,6 +6,11 @@ import {
 import { checkInvalidActionTypeInArray } from './utils/validation';
 import { createStandardAction } from './create-standard-action';
 
+export type ExcludeNever<T extends object> = Pick<
+  T,
+  { [Key in keyof T]: T[Key] extends never ? never : Key }[keyof T]
+>;
+
 export type AsyncActionCreator<
   TRequest extends [T1, P1],
   TSuccess extends [T2, P2],
@@ -19,14 +24,14 @@ export type AsyncActionCreator<
   P3 = TFailure[1],
   T4 extends TypeConstant = TCancel[0],
   P4 = TCancel[1]
-> = {
+> = ExcludeNever<{
   request: ActionBuilderConstructor<T1, P1>;
   success: ActionBuilderConstructor<T2, P2>;
   failure: ActionBuilderConstructor<T3, P3>;
   cancel: TCancel extends [TypeConstant, any]
     ? ActionBuilderConstructor<T4, P4>
     : never;
-};
+}>;
 
 export interface AsyncActionBuilder<
   TType1 extends TypeConstant,


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
Remove `cancel` properties from `createAsyncAction` when it's never, because it generates error on test suite:
```ts
// file.ts
import { createAsyncAction } from './create-async-action';

const toto = createAsyncAction('Test', 'test1', 'test2')<
  undefined,
  { test: string },
  { error: string }
>();
```
```ts
// file.spec.ts
const test: typeof toto = { // Property 'cancel' is missing in type '{ failure: (e: { error: string; }) => any; request: () => any; success: (e: { test: string; }) => any; }' but required in type 'AsyncActionCreator<["Test", undefined], ["test1", { test: string; }], ["test2", { error: string; }], never, "Test", undefined, "test1", { test: string; }, "test2", { error: string; }, never, never>'.ts(2741)
  failure: e => false as any,
  request: () => false as any,
  success: e => false as any,
};
```
![image](https://user-images.githubusercontent.com/5469433/57754191-e955dd00-76fe-11e9-8d9a-8d913b992e63.png)
```ts
// file.spec.ts
const test: typeof toto = {
  failure: e => false as any,
  request: () => false as any,
  success: e => false as any,
  cancel: null, // or undefined => Type 'null' is not assignable to type 'never'.
};
```
![image](https://user-images.githubusercontent.com/5469433/57754137-cfb49580-76fe-11e9-8e98-950276bfc8bc.png)

So during my test on my application, I need to patch this `cancel` attribute.

What do you think if we remove it when it's `never`?:
![image](https://user-images.githubusercontent.com/5469433/57754365-4e113780-76ff-11e9-8fa4-813f0514d2d7.png)


## Checklist

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
* [x] I have linked all related issues above
* [x] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
* [ ] I have added runtime unit tests with `dts-jest`
