### PR TITLE
fix: expose InitialHandler type

### DIFF
--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -63,7 +63,7 @@ type GetAction<
   TType extends TAction['type']
 > = TAction extends Action<TType> ? TAction : never;
 
-type InitialHandler<TState, TRootAction extends Action> = {
+export type InitialHandler<TState, TRootAction extends Action> = {
   [P in TRootAction['type']]?: (
     state: TState,
     action: GetAction<TRootAction, P>


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
This PR will expose `InitialHandler` so it can be used for variable definitions outside of `typesafe-actions`.

## Related issues:
https://github.com/piotrwitek/typesafe-actions/issues/224

## Checklist

* [X] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/typesafe-actions/blob/master/CONTRIBUTING.md)
* [X] I have linked all related issues above
* [X] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
* [ ] I have added runtime unit tests with `dts-jest`
