### PR TITLE
feat(README): Remove unused import from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ We can extend internal types of `typesafe-actions` module with `RootAction` defi
 
 ```ts
 // types.d.ts
-import { StateType, ActionType } from 'typesafe-actions';
+import { ActionType } from 'typesafe-actions';
 
 export type RootAction = ActionType<typeof import('./actions').default>;
 


### PR DESCRIPTION
## Description
I noticed that there was an unused import in one of the README examples. This PR simply removes it. Given it is such a minor thing I didn't consider it necessary to first create an issue in this case as outlined in the contributing readme.

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/typesafe-actions/blob/master/CONTRIBUTING.md)
* [x] I have rebased my branch
