### PR TITLE
Optimize tsc start time in watch mode for big projects

### DIFF
--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -6,7 +6,7 @@ import {
 } from './utils/validation';
 import { Reducer, Action, Types } from './type-helpers';
 
-type HandleActionChainApi<
+export type HandleActionChainApi<
   TState,
   TInputAction extends Action,
   TRootAction extends Action
@@ -32,7 +32,7 @@ type HandleActionChainApi<
       >;
     };
 
-type HandleTypeChainApi<
+export type HandleTypeChainApi<
   TState,
   TInputAction extends Action,
   TRootAction extends Action


### PR DESCRIPTION
## Description

Hi!

I have a problem in a big project that uses typesafe-actions. `tsc` in watch mode starts many times slower than a standalone check. 

After some googling and debugging I think I found the root cause of the slow down. 
Looks like tsc in watch mode generates temporary declaration (d.ts) files for incremental checks. And it turned out that generated typings for reducers are really big so that tsc spends a lot of time producing these temp files when starting. 

The declaration files are big because of the recursive types that typescript doesn't handle well. For instance, this is what tsc produces for `benchmarks/10-actions.ts` from this repo - https://gist.github.com/11bit/ae4a19748c0ffaec44db4f2890e030d8. Looks like typescript tries to unfold them or something. 

The workaround to optimize it is to expose these internal recursive types HandleActionChainApi and HandleTypeChainApi, so that tsc will be able to use them as is. 

There is a discussion about a similar issue in typescript repo https://github.com/microsoft/TypeScript/issues/34119

## Related issues:
- Resolved #XXX

## Checklist

* [ ] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/typesafe-actions/blob/master/CONTRIBUTING.md)
* [ ] I have linked all related issues above
* [ ] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [ ] I have added entry in TOC and API Docs
* [ ] I have added a short example in API Docs to demonstrate new usage
* [ ] I have added type unit tests with `dts-jest`
* [ ] I have added runtime unit tests with `dts-jest`
