### PR TITLE
Reducers: add default handler (without init action handling)

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/typesafe-actions.cjs.development.js": {
-    "bundled": 9523,
-    "minified": 5402,
-    "gzipped": 1351
+    "bundled": 9422,
+    "minified": 5365,
+    "gzipped": 1319
   },
   "dist/typesafe-actions.cjs.production.js": {
-    "bundled": 9523,
-    "minified": 5402,
-    "gzipped": 1351
+    "bundled": 9422,
+    "minified": 5365,
+    "gzipped": 1319
   },
   "dist/typesafe-actions.es.production.js": {
-    "bundled": 9333,
-    "minified": 5229,
-    "gzipped": 1315,
+    "bundled": 9232,
+    "minified": 5192,
+    "gzipped": 1284,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -24,13 +24,13 @@
     }
   },
   "dist/typesafe-actions.umd.development.js": {
-    "bundled": 10981,
-    "minified": 4180,
-    "gzipped": 1331
+    "bundled": 10876,
+    "minified": 4143,
+    "gzipped": 1300
   },
   "dist/typesafe-actions.umd.production.js": {
-    "bundled": 10981,
-    "minified": 4180,
-    "gzipped": 1331
+    "bundled": 10876,
+    "minified": 4143,
+    "gzipped": 1300
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/typesafe-actions.cjs.development.js": {
-    "bundled": 9908,
-    "minified": 5455,
-    "gzipped": 1373
+    "bundled": 9523,
+    "minified": 5402,
+    "gzipped": 1351
   },
   "dist/typesafe-actions.cjs.production.js": {
-    "bundled": 9908,
-    "minified": 5455,
-    "gzipped": 1373
+    "bundled": 9523,
+    "minified": 5402,
+    "gzipped": 1351
   },
   "dist/typesafe-actions.es.production.js": {
-    "bundled": 9718,
-    "minified": 5282,
-    "gzipped": 1336,
+    "bundled": 9333,
+    "minified": 5229,
+    "gzipped": 1315,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -24,13 +24,13 @@
     }
   },
   "dist/typesafe-actions.umd.development.js": {
-    "bundled": 11390,
-    "minified": 4233,
-    "gzipped": 1349
+    "bundled": 10981,
+    "minified": 4180,
+    "gzipped": 1331
   },
   "dist/typesafe-actions.umd.production.js": {
-    "bundled": 11390,
-    "minified": 4233,
-    "gzipped": 1349
+    "bundled": 10981,
+    "minified": 4180,
+    "gzipped": 1331
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/typesafe-actions.cjs.development.js": {
-    "bundled": 9154,
-    "minified": 5296,
-    "gzipped": 1299
+    "bundled": 9438,
+    "minified": 5374,
+    "gzipped": 1324
   },
   "dist/typesafe-actions.cjs.production.js": {
-    "bundled": 9154,
-    "minified": 5296,
-    "gzipped": 1299
+    "bundled": 9438,
+    "minified": 5374,
+    "gzipped": 1324
   },
   "dist/typesafe-actions.es.production.js": {
-    "bundled": 8964,
-    "minified": 5123,
-    "gzipped": 1262,
+    "bundled": 9248,
+    "minified": 5201,
+    "gzipped": 1288,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -24,13 +24,13 @@
     }
   },
   "dist/typesafe-actions.umd.development.js": {
-    "bundled": 10584,
-    "minified": 4086,
-    "gzipped": 1270
+    "bundled": 10892,
+    "minified": 4152,
+    "gzipped": 1304
   },
   "dist/typesafe-actions.umd.production.js": {
-    "bundled": 10584,
-    "minified": 4086,
-    "gzipped": 1270
+    "bundled": 10892,
+    "minified": 4152,
+    "gzipped": 1304
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,18 +1,18 @@
 {
   "dist/typesafe-actions.cjs.development.js": {
-    "bundled": 9438,
-    "minified": 5374,
-    "gzipped": 1324
+    "bundled": 9908,
+    "minified": 5455,
+    "gzipped": 1373
   },
   "dist/typesafe-actions.cjs.production.js": {
-    "bundled": 9438,
-    "minified": 5374,
-    "gzipped": 1324
+    "bundled": 9908,
+    "minified": 5455,
+    "gzipped": 1373
   },
   "dist/typesafe-actions.es.production.js": {
-    "bundled": 9248,
-    "minified": 5201,
-    "gzipped": 1288,
+    "bundled": 9718,
+    "minified": 5282,
+    "gzipped": 1336,
     "treeshaked": {
       "rollup": {
         "code": 0,
@@ -24,13 +24,13 @@
     }
   },
   "dist/typesafe-actions.umd.development.js": {
-    "bundled": 10892,
-    "minified": 4152,
-    "gzipped": 1304
+    "bundled": 11390,
+    "minified": 4233,
+    "gzipped": 1349
   },
   "dist/typesafe-actions.umd.production.js": {
-    "bundled": 10892,
-    "minified": 4152,
-    "gzipped": 1304
+    "bundled": 11390,
+    "minified": 4233,
+    "gzipped": 1349
   }
 }

--- a/README.md
+++ b/README.md
@@ -398,15 +398,6 @@ store.dispatch(add(3));
 store.dispatch(reset());
 ```
 
-The `defaultHandler` isn't invoked at initialization of the redux store (default behavior).
-To enforce invoking the `defaultHandler` at initialization of the redux store, supply `true` as second argument to the `defaultHandler`.
-Note, that the initialization action doesn't have a payload.
-```ts
-const counterReducer = createReducer(0)
-  .handleAction(add, (state, action) => state + action.payload)
-  .defaultHandler((state, action) => state = 0, true);
-```
-
 #### Alternative usage with regular switch reducer
 
 First we need to start by generating a **tagged union type** of actions (`TodosAction`). It's very easy to do by using `ActionType` **type-helper**.

--- a/README.md
+++ b/README.md
@@ -386,6 +386,8 @@ counterReducer(0, increment()); // => 1
 ```
 
 A default handler can be attached, which is invoked for all actions not associated with a handler.
+Please be aware that the defaultHandler may be triggered by the initialization process of the Redux store or by actions dispatched from some other libraries used as middleware, causing the state to be updated.
+
 ```ts
 const rootReducer = combineReducers({ /* ... */ });
 type RootState = StateType<typeof rootReducer>;

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ counterReducer(0, add(4)); // => 4
 counterReducer(0, increment()); // => 1
 ```
 
-A default handler can be attached, which is called upon an empty `type` property.
+A default handler can be attached, which is invoked for all actions not associated with a handler.
 ```ts
 const add = createAction('todos/ADD', length => length)<number>();
 const reset = createAction('', () => 0)<number>();
@@ -396,6 +396,15 @@ const counterReducer = createReducer(0)
 const store = createStore(counterReducer);
 store.dispatch(add(3));
 store.dispatch(reset());
+```
+
+The `defaultHandler` isn't invoked at initialization of the redux store (default behavior).
+To enforce invoking the `defaultHandler` at initialization of the redux store, supply `true` as second argument to the `defaultHandler`.
+Note, that the initialization action doesn't have a payload.
+```ts
+const counterReducer = createReducer(0)
+  .handleAction(add, (state, action) => state + action.payload)
+  .defaultHandler((state, action) => state = 0, true);
 ```
 
 #### Alternative usage with regular switch reducer

--- a/README.md
+++ b/README.md
@@ -385,6 +385,19 @@ counterReducer(0, add(4)); // => 4
 counterReducer(0, increment()); // => 1
 ```
 
+A default handler can be attached, which is called upon an empty `type` property.
+```ts
+const add = createAction('todos/ADD', length => length)<number>();
+const reset = createAction('', () => 0)<number>();
+const counterReducer = createReducer(0)
+  .handleAction(add, (state, action) => state + action.payload)
+  .defaultHandler((state, action) => state = action.payload);
+
+const store = createStore(counterReducer);
+store.dispatch(add(3));
+store.dispatch(reset());
+```
+
 #### Alternative usage with regular switch reducer
 
 First we need to start by generating a **tagged union type** of actions (`TodosAction`). It's very easy to do by using `ActionType` **type-helper**.

--- a/README.md
+++ b/README.md
@@ -387,15 +387,12 @@ counterReducer(0, increment()); // => 1
 
 A default handler can be attached, which is invoked for all actions not associated with a handler.
 ```ts
-const add = createAction('todos/ADD', length => length)<number>();
-const reset = createAction('', () => 0)<number>();
-const counterReducer = createReducer(0)
-  .handleAction(add, (state, action) => state + action.payload)
-  .defaultHandler((state, action) => state = action.payload);
-
-const store = createStore(counterReducer);
-store.dispatch(add(3));
-store.dispatch(reset());
+const rootReducer = combineReducers({ /* ... */ });
+type RootState = StateType<typeof rootReducer>;
+const signOut = createAction('root/SIGN_OUT');
+export default createReducer(undefined as RootState)
+  .handleAction(signOut, (state, action) => rootReducer(undefined, action))
+  .defaultHandler((state, action) => rootReducer(state, action))
 ```
 
 #### Alternative usage with regular switch reducer

--- a/src/__snapshots__/create-reducer.spec.ts.snap
+++ b/src/__snapshots__/create-reducer.spec.ts.snap
@@ -12,6 +12,8 @@ exports[`Type refinement checks action (type) should match snapshot 5`] = `"T.Em
 
 exports[`Type refinement checks reducer.handlers (type) should match snapshot 1`] = `"Record<\\"foo1\\" | \\"foo2\\" | \\"foo3\\" | \\"foo4\\" | \\"foo5\\", (state: { foo: string | null; }, action: T.PayloadAction<\\"foo1\\", string> | T.PayloadAction<\\"foo2\\", string> | T.EmptyAction<\\"foo3\\"> | T.EmptyAction<\\"foo4\\"> | T.EmptyAction<\\"foo5\\">) => { foo: string | null; }>"`;
 
+exports[`Type refinement checks reducerDefaultResult (type) should match snapshot 1`] = `"{ foo: string | null; }"`;
+
 exports[`Type refinement checks reducerResult (type) should match snapshot 1`] = `"{ foo: string | null; }"`;
 
 exports[`Type refinement checks reducerResult (type) should match snapshot 2`] = `"{ foo: string | null; }"`;
@@ -19,8 +21,6 @@ exports[`Type refinement checks reducerResult (type) should match snapshot 2`] =
 exports[`Type refinement checks reducerResult (type) should match snapshot 3`] = `"{ foo: string | null; }"`;
 
 exports[`Type refinement checks reducerResult (type) should match snapshot 4`] = `"{ foo: string | null; }"`;
-
-exports[`Type refinement checks reducerResult (type) should match snapshot 5`] = `"{ foo: string | null; }"`;
 
 exports[`Type refinement checks state (type) should match snapshot 1`] = `"{ foo: string | null; }"`;
 

--- a/src/__snapshots__/create-reducer.spec.ts.snap
+++ b/src/__snapshots__/create-reducer.spec.ts.snap
@@ -8,7 +8,9 @@ exports[`Type refinement checks action (type) should match snapshot 3`] = `"T.Em
 
 exports[`Type refinement checks action (type) should match snapshot 4`] = `"T.EmptyAction<\\"foo4\\">"`;
 
-exports[`Type refinement checks reducer.handlers (type) should match snapshot 1`] = `"Record<\\"foo1\\" | \\"foo2\\" | \\"foo3\\" | \\"foo4\\", (state: { foo: string | null; }, action: T.PayloadAction<\\"foo1\\", string> | T.PayloadAction<\\"foo2\\", string> | T.EmptyAction<\\"foo3\\"> | T.EmptyAction<\\"foo4\\">) => { foo: string | null; }>"`;
+exports[`Type refinement checks action (type) should match snapshot 5`] = `"T.EmptyAction<\\"foo5\\">"`;
+
+exports[`Type refinement checks reducer.handlers (type) should match snapshot 1`] = `"Record<\\"foo1\\" | \\"foo2\\" | \\"foo3\\" | \\"foo4\\" | \\"foo5\\", (state: { foo: string | null; }, action: T.PayloadAction<\\"foo1\\", string> | T.PayloadAction<\\"foo2\\", string> | T.EmptyAction<\\"foo3\\"> | T.EmptyAction<\\"foo4\\"> | T.EmptyAction<\\"foo5\\">) => { foo: string | null; }>"`;
 
 exports[`Type refinement checks reducerResult (type) should match snapshot 1`] = `"{ foo: string | null; }"`;
 
@@ -18,6 +20,8 @@ exports[`Type refinement checks reducerResult (type) should match snapshot 3`] =
 
 exports[`Type refinement checks reducerResult (type) should match snapshot 4`] = `"{ foo: string | null; }"`;
 
+exports[`Type refinement checks reducerResult (type) should match snapshot 5`] = `"{ foo: string | null; }"`;
+
 exports[`Type refinement checks state (type) should match snapshot 1`] = `"{ foo: string | null; }"`;
 
 exports[`Type refinement checks state (type) should match snapshot 2`] = `"{ foo: string | null; }"`;
@@ -26,18 +30,24 @@ exports[`Type refinement checks state (type) should match snapshot 3`] = `"{ foo
 
 exports[`Type refinement checks state (type) should match snapshot 4`] = `"{ foo: string | null; }"`;
 
-exports[`With Action Creators counterReducer1.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`Type refinement checks state (type) should match snapshot 5`] = `"{ foo: string | null; }"`;
 
-exports[`With Action Creators counterReducer2.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Creators counterReducer1.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Creators counterReducer3.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Creators counterReducer2.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Creators counterReducer4.handlers (type) should match snapshot 1`] = `"Record<\\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Creators counterReducer3.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Types counterReducer1.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Creators counterReducer4.handlers (type) should match snapshot 1`] = `"Record<\\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Types counterReducer2.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Creators counterReducer5.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\" | \\"DECREMENT\\" | \\"@@redux/INIT.1\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Types counterReducer3.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Types counterReducer1.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
 
-exports[`With Action Types counterReducer4.handlers (type) should match snapshot 1`] = `"Record<\\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\">) => number>"`;
+exports[`With Action Types counterReducer2.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
+
+exports[`With Action Types counterReducer3.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
+
+exports[`With Action Types counterReducer4.handlers (type) should match snapshot 1`] = `"Record<\\"INCREMENT\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;
+
+exports[`With Action Types counterReducer5.handlers (type) should match snapshot 1`] = `"Record<\\"ADD\\" | \\"INCREMENT\\" | \\"DECREMENT\\" | \\"@@redux/INIT.1\\", (state: number, action: T.PayloadAction<\\"ADD\\", number> | T.EmptyAction<\\"INCREMENT\\"> | T.EmptyAction<\\"DECREMENT\\"> | T.EmptyAction<\\"@@redux/INIT.1\\">) => number>"`;

--- a/src/create-reducer.spec.snap.ts
+++ b/src/create-reducer.spec.snap.ts
@@ -106,8 +106,6 @@ const initialState = 0;
       fn(0, add(4)); // => 4
     });
     // @dts-jest:pass
-    counterReducer5(0, reduxInit()); // => 0
-    // @dts-jest:pass
     counterReducer5(0, {} as any); // => 1
     // @dts-jest:pass
     counterReducer5(0, add(4)); // => 4
@@ -298,8 +296,6 @@ const initialState = 0;
       // @dts-jest:pass
       fn(0, add(4)); // => 4
     });
-    // @dts-jest:pass
-    counterReducer5(0, reduxInit()); // => 0;
     // @dts-jest:pass
     counterReducer5(0, increment()); // => 1;
     // @dts-jest:pass

--- a/src/create-reducer.spec.snap.ts
+++ b/src/create-reducer.spec.snap.ts
@@ -12,7 +12,7 @@ const actions = {
   add,
   increment,
   decrement,
-  reduxInit
+  reduxInit,
 };
 
 declare module './type-helpers' {
@@ -71,13 +71,8 @@ const initialState = 0;
   Object.keys({ ...emptyReducer.handlers }); // => []
 
   const counterReducer5 = emptyReducer
-    .handleAction(
-      add,
-      (state, action) => state + action.payload
-    )
-    .defaultHandler(
-       (state, action) => state + 1
-    );
+    .handleAction(add, (state, action) => state + action.payload)
+    .defaultHandler((state, action) => state + 1);
 
   // @dts-jest:pass:snap -> Record<"ADD" | "INCREMENT" | "DECREMENT" | "@@redux/INIT.1", (state: number, action: T.PayloadAction<"ADD", number> | T.EmptyAction<"INCREMENT"> | T.EmptyAction<"DECREMENT"> | T.EmptyAction<"@@redux/INIT.1">) => number>
   counterReducer5.handlers;
@@ -216,9 +211,9 @@ const initialState = 0;
       reducerResult; // => { foo: "empty" }
     });
 
-    const reducerResult = reducer(defaultState, actions2.foo5());
+    const reducerDefaultResult = reducer(defaultState, actions2.foo5());
     // @dts-jest:pass:snap -> { foo: string | null; }
-    reducerResult; // => { foo: "default" }
+    reducerDefaultResult; // => { foo: "default" }
   }
 }
 
@@ -271,7 +266,7 @@ const initialState = 0;
 
   const counterReducer5 = reducerTest
     .handleType(['ADD'], (state, action) => state + action.payload)
-    .defaultHandler((state, action) => state + 1)
+    .defaultHandler((state, action) => state + 1);
   // @dts-jest:pass:snap -> Record<"ADD" | "INCREMENT" | "DECREMENT" | "@@redux/INIT.1", (state: number, action: T.PayloadAction<"ADD", number> | T.EmptyAction<"INCREMENT"> | T.EmptyAction<"DECREMENT"> | T.EmptyAction<"@@redux/INIT.1">) => number>
   counterReducer5.handlers;
   // @dts-jest:pass

--- a/src/create-reducer.spec.ts
+++ b/src/create-reducer.spec.ts
@@ -12,7 +12,7 @@ const actions = {
   add,
   increment,
   decrement,
-  reduxInit
+  reduxInit,
 };
 
 declare module './type-helpers' {
@@ -71,13 +71,8 @@ const initialState = 0;
   Object.keys({ ...emptyReducer.handlers }); // => []
 
   const counterReducer5 = emptyReducer
-    .handleAction(
-      add,
-      (state, action) => state + action.payload
-    )
-    .defaultHandler(
-       (state, action) => state + 1
-    );
+    .handleAction(add, (state, action) => state + action.payload)
+    .defaultHandler((state, action) => state + 1);
 
   // @dts-jest:pass:snap
   counterReducer5.handlers;
@@ -216,9 +211,9 @@ const initialState = 0;
       reducerResult; // => { foo: "empty" }
     });
 
-    const reducerResult = reducer(defaultState, actions2.foo5());
+    const reducerDefaultResult = reducer(defaultState, actions2.foo5());
     // @dts-jest:pass:snap
-    reducerResult; // => { foo: "default" }
+    reducerDefaultResult; // => { foo: "default" }
   }
 }
 
@@ -271,7 +266,7 @@ const initialState = 0;
 
   const counterReducer5 = reducerTest
     .handleType(['ADD'], (state, action) => state + action.payload)
-    .defaultHandler((state, action) => state + 1)
+    .defaultHandler((state, action) => state + 1);
   // @dts-jest:pass:snap
   counterReducer5.handlers;
   // @dts-jest:pass

--- a/src/create-reducer.spec.ts
+++ b/src/create-reducer.spec.ts
@@ -7,10 +7,12 @@ import { getType } from './get-type';
 const add = createAction('ADD')<number>();
 const increment = createAction('INCREMENT')();
 const decrement = createAction('DECREMENT')();
+const reduxInit = createAction('@@redux/INIT.1')();
 const actions = {
   add,
   increment,
   decrement,
+  reduxInit
 };
 
 declare module './type-helpers' {
@@ -68,6 +70,22 @@ const initialState = 0;
   // @dts-jest:pass
   Object.keys({ ...emptyReducer.handlers }); // => []
 
+  const counterReducer5 = emptyReducer
+    .handleAction(
+      add,
+      (state, action) => state + action.payload
+    )
+    .defaultHandler(
+       (state, action) => state + 1
+    );
+
+  // @dts-jest:pass:snap
+  counterReducer5.handlers;
+  // @dts-jest:pass
+  Object.keys({ ...counterReducer5.handlers }); // => [ "ADD"]
+  // @dts-jest:pass
+  Object.keys({ ...emptyReducer.handlers }); // => []
+
   {
     [
       counterReducer1,
@@ -92,6 +110,12 @@ const initialState = 0;
       // @dts-jest:pass
       fn(0, add(4)); // => 4
     });
+    // @dts-jest:pass
+    counterReducer5(0, reduxInit()); // => 0
+    // @dts-jest:pass
+    counterReducer5(0, {} as any); // => 1
+    // @dts-jest:pass
+    counterReducer5(0, add(4)); // => 4
   }
 }
 
@@ -110,6 +134,7 @@ const initialState = 0;
     foo2: createAction('foo2')<string>(),
     foo3: createAction('foo3')(),
     foo4: createAction('foo4')(),
+    foo5: createAction('foo5')(),
   };
 
   type Action = ActionType<typeof actions2>;
@@ -158,6 +183,17 @@ const initialState = 0;
         ...state,
         foo: 'empty',
       };
+    })
+    .defaultHandler((state, action) => {
+      // @dts-jest:pass:snap
+      state;
+      // @dts-jest:pass:snap
+      action;
+
+      return {
+        ...state,
+        foo: 'default',
+      };
     });
 
   // @dts-jest:pass:snap
@@ -179,6 +215,10 @@ const initialState = 0;
       // @dts-jest:pass:snap
       reducerResult; // => { foo: "empty" }
     });
+
+    const reducerResult = reducer(defaultState, actions2.foo5());
+    // @dts-jest:pass:snap
+    reducerResult; // => { foo: "default" }
   }
 }
 
@@ -229,6 +269,16 @@ const initialState = 0;
   // @dts-jest:pass
   Object.keys({ ...reducerTest.handlers }); // => []
 
+  const counterReducer5 = reducerTest
+    .handleType(['ADD'], (state, action) => state + action.payload)
+    .defaultHandler((state, action) => state + 1)
+  // @dts-jest:pass:snap
+  counterReducer5.handlers;
+  // @dts-jest:pass
+  Object.keys({ ...counterReducer5.handlers }); // => [ "ADD"]
+  // @dts-jest:pass
+  Object.keys({ ...reducerTest.handlers }); // => []
+
   {
     [
       counterReducer1,
@@ -253,5 +303,11 @@ const initialState = 0;
       // @dts-jest:pass
       fn(0, add(4)); // => 4
     });
+    // @dts-jest:pass
+    counterReducer5(0, reduxInit()); // => 0;
+    // @dts-jest:pass
+    counterReducer5(0, increment()); // => 1;
+    // @dts-jest:pass
+    counterReducer5(0, add(4)); // => 4;
   }
 }

--- a/src/create-reducer.spec.ts
+++ b/src/create-reducer.spec.ts
@@ -106,8 +106,6 @@ const initialState = 0;
       fn(0, add(4)); // => 4
     });
     // @dts-jest:pass
-    counterReducer5(0, reduxInit()); // => 0
-    // @dts-jest:pass
     counterReducer5(0, {} as any); // => 1
     // @dts-jest:pass
     counterReducer5(0, add(4)); // => 4
@@ -298,8 +296,6 @@ const initialState = 0;
       // @dts-jest:pass
       fn(0, add(4)); // => 4
     });
-    // @dts-jest:pass
-    counterReducer5(0, reduxInit()); // => 0;
     // @dts-jest:pass
     counterReducer5(0, increment()); // => 1;
     // @dts-jest:pass

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -24,6 +24,35 @@ type HandleActionChainApi<
         (state: TState, action: TRootAction) => TState
       >;
       handleAction: HandleActionChainApi<TState, TOutputAction, TRootAction>;
+      defaultHandler: HandleDefaultActionChainApi<
+        TState,
+        TOutputAction,
+        TRootAction
+      >;
+    }
+  : Reducer<TState, TRootAction> & {
+      handlers: Record<
+        TRootAction['type'],
+        (state: TState, action: TRootAction) => TState
+      >;
+    };
+
+type HandleDefaultActionChainApi<
+  TState,
+  TInputAction extends Action,
+  TRootAction extends Action
+> = <
+  TActionCreator extends (...args: any[]) => TInputAction,
+  THandledAction extends ReturnType<TActionCreator>,
+  TOutputAction extends Exclude<TInputAction, THandledAction>
+>(
+  reducer: (state: TState, action: THandledAction) => TState
+) => [TOutputAction] extends [Action]
+  ? Reducer<TState, TRootAction> & {
+      handlers: Record<
+        Exclude<TRootAction, TOutputAction>['type'],
+        (state: TState, action: TRootAction) => TState
+      >;
     }
   : Reducer<TState, TRootAction> & {
       handlers: Record<
@@ -50,6 +79,11 @@ type HandleTypeChainApi<
         (state: TState, action: TRootAction) => TState
       >;
       handleType: HandleTypeChainApi<TState, TOutputAction, TRootAction>;
+      defaultHandler: HandleDefaultActionChainApi<
+        TState,
+        TOutputAction,
+        TRootAction
+      >;
     }
   : Reducer<TState, TRootAction> & {
       handlers: Record<
@@ -74,7 +108,8 @@ type RootAction = Types extends { RootAction: infer T } ? T : any;
 
 export function createReducer<TState, TRootAction extends Action = RootAction>(
   initialState: TState,
-  initialHandlers: InitialHandler<TState, TRootAction> = {}
+  initialHandlers: InitialHandler<TState, TRootAction> = {},
+  defaultReducer?: Reducer<TState, TRootAction>
 ) {
   const handlers: any = {
     ...initialHandlers,
@@ -92,6 +127,8 @@ export function createReducer<TState, TRootAction extends Action = RootAction>(
         );
       }
       return reducer(state, action);
+    } else if (defaultReducer && !action.type) {
+      return defaultReducer(state, action);
     } else {
       return state;
     }
@@ -121,18 +158,27 @@ export function createReducer<TState, TRootAction extends Action = RootAction>(
       )
       .forEach(type => (newHandlers[type] = reducer));
 
-    return createReducer<TState, TRootAction>(initialState, {
-      ...handlers,
-      ...newHandlers,
-    });
+    return createReducer<TState, TRootAction>(
+      initialState,
+      {
+        ...handlers,
+        ...newHandlers,
+      },
+      defaultReducer
+    );
   }) as
     | HandleActionChainApi<TState, TRootAction, TRootAction>
     | HandleTypeChainApi<TState, TRootAction, TRootAction>;
+
+  const defaultHandler = ((reducer: any) => {
+    return createReducer<TState, TRootAction>(initialState, handlers, reducer);
+  }) as HandleDefaultActionChainApi<TState, TRootAction, TRootAction>;
 
   const chainApi = Object.assign(rootReducer, {
     handlers: { ...handlers },
     handleAction: reducerHandler,
     handleType: reducerHandler,
+    defaultHandler,
   }) as Reducer<TState, TRootAction> &
     Readonly<{
       handlers: InitialHandler<TState, RootAction>;
@@ -142,6 +188,9 @@ export function createReducer<TState, TRootAction extends Action = RootAction>(
       handleType: [unknown] extends [TRootAction]
         ? any
         : HandleTypeChainApi<TState, TRootAction, TRootAction>;
+      defaultHandler: [unknown] extends [TRootAction]
+        ? any
+        : HandleDefaultActionChainApi<TState, TRootAction, TRootAction>;
     }>;
 
   return chainApi;

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -47,7 +47,7 @@ type HandleDefaultActionChainApi<
   TOutputAction extends Exclude<TInputAction, THandledAction>
 >(
   reducer: (state: TState, action: THandledAction) => TState,
-  executeAtInitialization: boolean
+  executeAtInitialization?: boolean
 ) => [TOutputAction] extends [Action]
   ? Reducer<TState, TRootAction> & {
       handlers: Record<

--- a/src/create-reducer.ts
+++ b/src/create-reducer.ts
@@ -46,7 +46,8 @@ type HandleDefaultActionChainApi<
   THandledAction extends ReturnType<TActionCreator>,
   TOutputAction extends Exclude<TInputAction, THandledAction>
 >(
-  reducer: (state: TState, action: THandledAction) => TState
+  reducer: (state: TState, action: THandledAction) => TState,
+  executeAtInitialization: boolean
 ) => [TOutputAction] extends [Action]
   ? Reducer<TState, TRootAction> & {
       handlers: Record<
@@ -109,11 +110,14 @@ type RootAction = Types extends { RootAction: infer T } ? T : any;
 export function createReducer<TState, TRootAction extends Action = RootAction>(
   initialState: TState,
   initialHandlers: InitialHandler<TState, TRootAction> = {},
-  defaultReducer?: Reducer<TState, TRootAction>
+  defaultReducer?: Reducer<TState, TRootAction>,
+  defaultReducerExecutedAtInitialization: boolean = false
 ) {
   const handlers: any = {
     ...initialHandlers,
   };
+
+  const initializationActionTypes = /@@redux\/INIT.*/;
 
   const rootReducer: Reducer<TState, TRootAction> = (
     state = initialState,
@@ -127,7 +131,12 @@ export function createReducer<TState, TRootAction extends Action = RootAction>(
         );
       }
       return reducer(state, action);
-    } else if (defaultReducer && !action.type) {
+    } else if (
+      defaultReducer &&
+      (defaultReducerExecutedAtInitialization ||
+        (!defaultReducerExecutedAtInitialization &&
+          !initializationActionTypes.test(action.type)))
+    ) {
       return defaultReducer(state, action);
     } else {
       return state;
@@ -170,8 +179,16 @@ export function createReducer<TState, TRootAction extends Action = RootAction>(
     | HandleActionChainApi<TState, TRootAction, TRootAction>
     | HandleTypeChainApi<TState, TRootAction, TRootAction>;
 
-  const defaultHandler = ((reducer: any) => {
-    return createReducer<TState, TRootAction>(initialState, handlers, reducer);
+  const defaultHandler = ((
+    reducer: any,
+    executeAtInitialization: boolean = false
+  ) => {
+    return createReducer<TState, TRootAction>(
+      initialState,
+      handlers,
+      reducer,
+      executeAtInitialization
+    );
   }) as HandleDefaultActionChainApi<TState, TRootAction, TRootAction>;
 
   const chainApi = Object.assign(rootReducer, {


### PR DESCRIPTION
<!-- Thank you for your contribution! :thumbsup: -->
<!-- Please makes sure that these checkboxes are checked before submitting your PR, thank you! -->

## Description
<!-- Example: Added error property support to `action` API -->
Adds a defaultHandler for reducers
apply https://github.com/piotrwitek/typesafe-actions/pull/241 's comments

## Related issues:
- Resolved #156 

## Checklist

* [x] I have read [CONTRIBUTING.md](https://github.com/piotrwitek/typesafe-actions/blob/master/CONTRIBUTING.md)
* [x] I have linked all related issues above
* [ ] I have rebased my branch

For bugfixes:
* [ ] I have added at least one unit test to confirm the bug have been fixed
* [ ] I have checked and updated TOC and API Docs when necessary

For new features:
* [x] I have added entry in TOC and API Docs
* [x] I have added a short example in API Docs to demonstrate new usage
* [x] I have added type unit tests with `dts-jest`
* [x] I have added runtime unit tests with `dts-jest`
