### PR TITLE
Add createAsyncEpic helper

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,36 +1,36 @@
 {
   "dist/typesafe-actions.cjs.development.js": {
-    "bundled": 9154,
-    "minified": 5296,
-    "gzipped": 1299
+    "bundled": 10675,
+    "minified": 6067,
+    "gzipped": 1534
   },
   "dist/typesafe-actions.cjs.production.js": {
-    "bundled": 9154,
-    "minified": 5296,
-    "gzipped": 1299
+    "bundled": 10675,
+    "minified": 6067,
+    "gzipped": 1534
   },
   "dist/typesafe-actions.es.production.js": {
-    "bundled": 8964,
-    "minified": 5123,
-    "gzipped": 1262,
+    "bundled": 10426,
+    "minified": 5830,
+    "gzipped": 1499,
     "treeshaked": {
       "rollup": {
-        "code": 0,
-        "import_statements": 0
+        "code": 36,
+        "import_statements": 36
       },
       "webpack": {
-        "code": 951
+        "code": 1053
       }
     }
   },
   "dist/typesafe-actions.umd.development.js": {
-    "bundled": 10584,
-    "minified": 4086,
-    "gzipped": 1270
+    "bundled": 12296,
+    "minified": 4733,
+    "gzipped": 1494
   },
   "dist/typesafe-actions.umd.production.js": {
-    "bundled": 10584,
-    "minified": 4086,
-    "gzipped": 1270
+    "bundled": 12296,
+    "minified": 4733,
+    "gzipped": 1494
   }
 }

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Found it useful? Want more updates?_
     - [`createStandardAction`](#createstandardaction)
     - [`createCustomAction`](#createcustomaction)
     - [`createAsyncAction`](#createasyncaction)
+    - [`createAsyncEpic`](#createasyncepic)
   - [Reducer-Creators API](#reducer-creators-api)
     - [`createReducer`](#createreducer)
   - [Action-Helpers API](#action-helpers-api)
@@ -450,6 +451,19 @@ const fetchTodosFlow: Epic<RootAction, RootAction, RootState, Services> = (actio
   );
 ```
 
+The same request/success/failure/cancel flow can be expressed with `createAsyncEpic`:
+
+```ts
+import { from } from 'rxjs';
+import { createAsyncEpic } from 'typesafe-actions';
+import { fetchTodosAsync } from './actions';
+
+const fetchTodosFlow: Epic<RootAction, RootAction, RootState, Services> =
+  createAsyncEpic(fetchTodosAsync, (action, _state$, { todosApi }) =>
+    from(todosApi.getAll(action.payload))
+  );
+```
+
 #### With `redux-saga` sagas
 With sagas it's not possible to achieve the same degree of type-safety as with epics because of limitations coming from `redux-saga` API design.
 
@@ -740,6 +754,55 @@ const fn = (
   >
 ) => a;
 fn(fetchUsersAsync);
+```
+
+[⇧ back to top](#table-of-contents)
+
+---
+
+#### `createAsyncEpic`
+
+_Create a `redux-observable` compatible epic from an async action object._
+
+```ts
+createAsyncEpic(asyncAction, handler, options?)
+```
+
+`createAsyncEpic` listens for `asyncAction.request`, calls `handler` with the request action, `state$` and dependencies, maps emitted values with `asyncAction.success`, maps errors with `asyncAction.failure`, and cancels the active request when `asyncAction.cancel` is dispatched.
+
+The helper uses switch-style request handling: a later request cancels the previous in-flight request. `rxjs` is required when using this helper.
+
+Examples:
+[> Advanced Usage Examples](src/create-async-epic.spec.ts)
+
+```ts
+import { Epic } from 'redux-observable';
+import { from } from 'rxjs';
+import { createAsyncAction, createAsyncEpic } from 'typesafe-actions';
+
+const fetchUserAsync = createAsyncAction(
+  'FETCH_USER_REQUEST',
+  'FETCH_USER_SUCCESS',
+  'FETCH_USER_FAILURE',
+  'FETCH_USER_CANCEL'
+)<string, User, HttpError, string>();
+
+const fetchUserEpic: Epic<RootAction, RootAction, RootState, Services> =
+  createAsyncEpic(fetchUserAsync, (action, state$, { userApi }) =>
+    from(userApi.fetch(action.payload, state$.value.authToken))
+  );
+
+const fetchUserWithErrorMapperEpic = createAsyncEpic(
+  fetchUserAsync,
+  (action, _state$, { userApi }: Services) =>
+    from(userApi.fetch(action.payload)),
+  {
+    mapError: error => ({
+      status: 500,
+      message: String(error),
+    }),
+  }
+);
 ```
 
 [⇧ back to top](#table-of-contents)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11251,6 +11251,15 @@
         "aproba": "^1.1.1"
       }
     },
+    "rxjs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
+      "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,13 @@
     "rollup-plugin-size-snapshot": "0.10.0",
     "rollup-plugin-sourcemaps": "0.4.2",
     "rollup-plugin-terser": "5.1.2",
+    "rxjs": "^6.5.3",
     "ts-jest": "24.1.0",
     "tslint": "5.20.1",
     "typescript": "3.7.2"
+  },
+  "peerDependencies": {
+    "rxjs": "^6.0.0"
   },
   "keywords": [
     "typescript",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,6 +55,10 @@ function createConfig(
         propertyReadSideEffects: false,
       },
       name: opts.name,
+      globals: {
+        rxjs: 'rxjs',
+        'rxjs/operators': 'rxjs.operators',
+      },
       sourcemap: true,
       // exports: 'named',
     },

--- a/src/__snapshots__/create-async-epic.spec.ts.snap
+++ b/src/__snapshots__/create-async-epic.spec.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`createAsyncEpic testType<
+      Observable<
+        | T.PayloadAction<'FETCH_USER_SUCCESS', User>
+        | T.PayloadAction<'FETCH_USER_FAILURE', HttpError>
+      >
+    >(epic(action$, state$, services)) (type) should match snapshot 1`] = `"Observable<T.PayloadAction<\\"FETCH_USER_SUCCESS\\", User> | T.PayloadAction<\\"FETCH_USER_FAILURE\\", HttpError>>"`;
+
+exports[`createAsyncEpic testType<Services>(deps) (type) should match snapshot 1`] = `"Services"`;
+
+exports[`createAsyncEpic testType<string>(action.payload) (type) should match snapshot 1`] = `"string"`;
+
+exports[`createAsyncEpic testType<string>(state.value.token) (type) should match snapshot 1`] = `"string"`;
+
+exports[`createAsyncEpic without cancel testType<
+      Observable<
+        | T.PayloadAction<'PING_SUCCESS', string>
+        | T.PayloadAction<'PING_FAILURE', Error>
+      >
+    >(epic(action$, state$, {})) (type) should match snapshot 1`] = `"Observable<T.PayloadAction<\\"PING_SUCCESS\\", string> | T.PayloadAction<\\"PING_FAILURE\\", Error>>"`;

--- a/src/create-async-epic.spec.snap.ts
+++ b/src/create-async-epic.spec.snap.ts
@@ -1,0 +1,303 @@
+// tslint:disable:import-blacklist
+import { Observable, of, Subject, throwError } from 'rxjs';
+
+import { createAsyncAction } from './create-async-action';
+import { createAsyncEpic } from './create-async-epic';
+import * as T from './type-helpers';
+import { testType } from './utils/testing';
+
+type User = {
+  id: string;
+  name: string;
+};
+
+type HttpError = {
+  status: number;
+  message: string;
+};
+
+type State$ = {
+  value: {
+    token: string;
+  };
+};
+
+type Services = {
+  getUser: (id: string, token: string) => Observable<User>;
+};
+
+const user: User = {
+  id: '42',
+  name: 'Piotr',
+};
+
+const httpError: HttpError = {
+  status: 500,
+  message: 'Server error',
+};
+
+const state$: State$ = {
+  value: {
+    token: 'token',
+  },
+};
+
+const fetchUserAsync = createAsyncAction(
+  'FETCH_USER_REQUEST',
+  'FETCH_USER_SUCCESS',
+  'FETCH_USER_FAILURE',
+  'FETCH_USER_CANCEL'
+)<string, User, HttpError, string>();
+
+const pingAsync = createAsyncAction(
+  'PING_REQUEST',
+  'PING_SUCCESS',
+  'PING_FAILURE'
+)<undefined, string, Error>();
+
+const otherAction = {
+  type: 'OTHER_ACTION',
+};
+
+type FetchUserAction = T.ActionType<typeof fetchUserAsync>;
+type PingAction = T.ActionType<typeof pingAsync>;
+type RootAction = FetchUserAction | PingAction | typeof otherAction;
+
+function collect<TValue>(
+  observable: Observable<TValue>,
+  onNext: (value: TValue) => void = () => undefined
+) {
+  return observable.subscribe(onNext);
+}
+
+describe('createAsyncEpic', () => {
+  it('maps request values to success actions', () => {
+    const services: Services = {
+      getUser: (id, token) => of({ ...user, id: `${id}:${token}` }),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (action, state, deps: Services) =>
+      deps.getUser(action.payload, state.value.token)
+    );
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(otherAction);
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([
+      fetchUserAsync.success({
+        id: '42:token',
+        name: 'Piotr',
+      }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('maps thrown and emitted errors to failure actions', () => {
+    const services: Services = {
+      getUser: () => throwError(httpError),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser('42', 'token'));
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([fetchUserAsync.failure(httpError)]);
+
+    subscription.unsubscribe();
+  });
+
+  it('supports custom error mapping with the original request action', () => {
+    const services = {};
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic(
+      fetchUserAsync,
+      action => {
+        throw new Error(action.payload);
+      },
+      {
+        mapError: (error, action) => ({
+          status: 400,
+          message: `${action.payload}:${(error as Error).message}`,
+        }),
+      }
+    );
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([
+      fetchUserAsync.failure({
+        status: 400,
+        message: '42:42',
+      }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('cancels the active request when cancel action is emitted', () => {
+    const response$ = new Subject<User>();
+    const services: Services = {
+      getUser: () => response$,
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser('42', 'token'));
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+    action$.next(fetchUserAsync.cancel('route-change'));
+    response$.next(user);
+
+    expect(actual).toEqual([]);
+
+    subscription.unsubscribe();
+  });
+
+  it('uses switch-style request handling', () => {
+    const firstResponse$ = new Subject<User>();
+    const secondResponse$ = new Subject<User>();
+    const services = {
+      getUser: jest
+        .fn()
+        .mockReturnValueOnce(firstResponse$)
+        .mockReturnValueOnce(secondResponse$),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      typeof services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser());
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('first'));
+    action$.next(fetchUserAsync.request('second'));
+    firstResponse$.next({ id: 'first', name: 'Ignored' });
+    secondResponse$.next({ id: 'second', name: 'Used' });
+
+    expect(actual).toEqual([
+      fetchUserAsync.success({ id: 'second', name: 'Used' }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('handles async action objects without cancel', () => {
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<typeof pingAsync, RootAction, State$, {}>(
+      pingAsync,
+      () => of('pong')
+    );
+    const subscription = collect(epic(action$, state$, {}), action =>
+      actual.push(action)
+    );
+
+    action$.next(pingAsync.request());
+
+    expect(actual).toEqual([pingAsync.success('pong')]);
+
+    subscription.unsubscribe();
+  });
+});
+
+// @dts-jest:group createAsyncEpic
+{
+  const services: Services = {
+    getUser: (id, token) => of({ ...user, id: `${id}:${token}` }),
+  };
+  const action$ = new Subject<RootAction>();
+
+  const epic = createAsyncEpic<
+    typeof fetchUserAsync,
+    RootAction,
+    State$,
+    Services
+  >(
+    fetchUserAsync,
+    (action, state, deps: Services) => {
+      // @dts-jest:pass:snap -> string
+      testType<string>(action.payload);
+
+      // @dts-jest:pass:snap -> string
+      testType<string>(state.value.token);
+
+      // @dts-jest:pass:snap -> Services
+      testType<Services>(deps);
+
+      return deps.getUser(action.payload, state.value.token);
+    },
+    {
+      mapError: (error, action) => ({
+        status: 500,
+        message: `${action.payload}:${String(error)}`,
+      }),
+    }
+  );
+
+  // @dts-jest:pass:snap -> Observable<T.PayloadAction<"FETCH_USER_SUCCESS", User> | T.PayloadAction<"FETCH_USER_FAILURE", HttpError>>
+  testType<
+    Observable<
+      | T.PayloadAction<'FETCH_USER_SUCCESS', User>
+      | T.PayloadAction<'FETCH_USER_FAILURE', HttpError>
+    >
+  >(epic(action$, state$, services));
+}
+
+// @dts-jest:group createAsyncEpic without cancel
+{
+  const action$ = new Subject<RootAction>();
+
+  const epic = createAsyncEpic<typeof pingAsync, RootAction, State$, {}>(
+    pingAsync,
+    () => of('pong')
+  );
+
+  // @dts-jest:pass:snap -> Observable<T.PayloadAction<"PING_SUCCESS", string> | T.PayloadAction<"PING_FAILURE", Error>>
+  testType<
+    Observable<
+      | T.PayloadAction<'PING_SUCCESS', string>
+      | T.PayloadAction<'PING_FAILURE', Error>
+    >
+  >(epic(action$, state$, {}));
+}

--- a/src/create-async-epic.spec.ts
+++ b/src/create-async-epic.spec.ts
@@ -1,0 +1,303 @@
+// tslint:disable:import-blacklist
+import { Observable, of, Subject, throwError } from 'rxjs';
+
+import { createAsyncAction } from './create-async-action';
+import { createAsyncEpic } from './create-async-epic';
+import * as T from './type-helpers';
+import { testType } from './utils/testing';
+
+type User = {
+  id: string;
+  name: string;
+};
+
+type HttpError = {
+  status: number;
+  message: string;
+};
+
+type State$ = {
+  value: {
+    token: string;
+  };
+};
+
+type Services = {
+  getUser: (id: string, token: string) => Observable<User>;
+};
+
+const user: User = {
+  id: '42',
+  name: 'Piotr',
+};
+
+const httpError: HttpError = {
+  status: 500,
+  message: 'Server error',
+};
+
+const state$: State$ = {
+  value: {
+    token: 'token',
+  },
+};
+
+const fetchUserAsync = createAsyncAction(
+  'FETCH_USER_REQUEST',
+  'FETCH_USER_SUCCESS',
+  'FETCH_USER_FAILURE',
+  'FETCH_USER_CANCEL'
+)<string, User, HttpError, string>();
+
+const pingAsync = createAsyncAction(
+  'PING_REQUEST',
+  'PING_SUCCESS',
+  'PING_FAILURE'
+)<undefined, string, Error>();
+
+const otherAction = {
+  type: 'OTHER_ACTION',
+};
+
+type FetchUserAction = T.ActionType<typeof fetchUserAsync>;
+type PingAction = T.ActionType<typeof pingAsync>;
+type RootAction = FetchUserAction | PingAction | typeof otherAction;
+
+function collect<TValue>(
+  observable: Observable<TValue>,
+  onNext: (value: TValue) => void = () => undefined
+) {
+  return observable.subscribe(onNext);
+}
+
+describe('createAsyncEpic', () => {
+  it('maps request values to success actions', () => {
+    const services: Services = {
+      getUser: (id, token) => of({ ...user, id: `${id}:${token}` }),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (action, state, deps: Services) =>
+      deps.getUser(action.payload, state.value.token)
+    );
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(otherAction);
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([
+      fetchUserAsync.success({
+        id: '42:token',
+        name: 'Piotr',
+      }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('maps thrown and emitted errors to failure actions', () => {
+    const services: Services = {
+      getUser: () => throwError(httpError),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser('42', 'token'));
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([fetchUserAsync.failure(httpError)]);
+
+    subscription.unsubscribe();
+  });
+
+  it('supports custom error mapping with the original request action', () => {
+    const services = {};
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic(
+      fetchUserAsync,
+      action => {
+        throw new Error(action.payload);
+      },
+      {
+        mapError: (error, action) => ({
+          status: 400,
+          message: `${action.payload}:${(error as Error).message}`,
+        }),
+      }
+    );
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+
+    expect(actual).toEqual([
+      fetchUserAsync.failure({
+        status: 400,
+        message: '42:42',
+      }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('cancels the active request when cancel action is emitted', () => {
+    const response$ = new Subject<User>();
+    const services: Services = {
+      getUser: () => response$,
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      Services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser('42', 'token'));
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('42'));
+    action$.next(fetchUserAsync.cancel('route-change'));
+    response$.next(user);
+
+    expect(actual).toEqual([]);
+
+    subscription.unsubscribe();
+  });
+
+  it('uses switch-style request handling', () => {
+    const firstResponse$ = new Subject<User>();
+    const secondResponse$ = new Subject<User>();
+    const services = {
+      getUser: jest
+        .fn()
+        .mockReturnValueOnce(firstResponse$)
+        .mockReturnValueOnce(secondResponse$),
+    };
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<
+      typeof fetchUserAsync,
+      RootAction,
+      State$,
+      typeof services
+    >(fetchUserAsync, (_action, _state, deps) => deps.getUser());
+    const subscription = collect(epic(action$, state$, services), action =>
+      actual.push(action)
+    );
+
+    action$.next(fetchUserAsync.request('first'));
+    action$.next(fetchUserAsync.request('second'));
+    firstResponse$.next({ id: 'first', name: 'Ignored' });
+    secondResponse$.next({ id: 'second', name: 'Used' });
+
+    expect(actual).toEqual([
+      fetchUserAsync.success({ id: 'second', name: 'Used' }),
+    ]);
+
+    subscription.unsubscribe();
+  });
+
+  it('handles async action objects without cancel', () => {
+    const action$ = new Subject<RootAction>();
+    const actual: RootAction[] = [];
+
+    const epic = createAsyncEpic<typeof pingAsync, RootAction, State$, {}>(
+      pingAsync,
+      () => of('pong')
+    );
+    const subscription = collect(epic(action$, state$, {}), action =>
+      actual.push(action)
+    );
+
+    action$.next(pingAsync.request());
+
+    expect(actual).toEqual([pingAsync.success('pong')]);
+
+    subscription.unsubscribe();
+  });
+});
+
+// @dts-jest:group createAsyncEpic
+{
+  const services: Services = {
+    getUser: (id, token) => of({ ...user, id: `${id}:${token}` }),
+  };
+  const action$ = new Subject<RootAction>();
+
+  const epic = createAsyncEpic<
+    typeof fetchUserAsync,
+    RootAction,
+    State$,
+    Services
+  >(
+    fetchUserAsync,
+    (action, state, deps: Services) => {
+      // @dts-jest:pass:snap
+      testType<string>(action.payload);
+
+      // @dts-jest:pass:snap
+      testType<string>(state.value.token);
+
+      // @dts-jest:pass:snap
+      testType<Services>(deps);
+
+      return deps.getUser(action.payload, state.value.token);
+    },
+    {
+      mapError: (error, action) => ({
+        status: 500,
+        message: `${action.payload}:${String(error)}`,
+      }),
+    }
+  );
+
+  // @dts-jest:pass:snap
+  testType<
+    Observable<
+      | T.PayloadAction<'FETCH_USER_SUCCESS', User>
+      | T.PayloadAction<'FETCH_USER_FAILURE', HttpError>
+    >
+  >(epic(action$, state$, services));
+}
+
+// @dts-jest:group createAsyncEpic without cancel
+{
+  const action$ = new Subject<RootAction>();
+
+  const epic = createAsyncEpic<typeof pingAsync, RootAction, State$, {}>(
+    pingAsync,
+    () => of('pong')
+  );
+
+  // @dts-jest:pass:snap
+  testType<
+    Observable<
+      | T.PayloadAction<'PING_SUCCESS', string>
+      | T.PayloadAction<'PING_FAILURE', Error>
+    >
+  >(epic(action$, state$, {}));
+}

--- a/src/create-async-epic.ts
+++ b/src/create-async-epic.ts
@@ -1,0 +1,120 @@
+// tslint:disable:import-blacklist
+import { from, Observable, ObservableInput, of } from 'rxjs';
+import { catchError, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+
+import {
+  ActionCreator as ActionCreatorWithMetadata,
+  isActionOf,
+} from './is-action-of';
+import { Action } from './type-helpers';
+
+type ActionCreator = ActionCreatorWithMetadata<Action>;
+
+type ActionFromCreator<TActionCreator extends ActionCreator> = ReturnType<
+  TActionCreator
+>;
+
+type FirstArgument<TActionCreator extends ActionCreator> = Parameters<
+  TActionCreator
+> extends []
+  ? undefined
+  : Parameters<TActionCreator>[0];
+
+export type AsyncActionCreatorMap<
+  TRequest extends ActionCreator = ActionCreator,
+  TSuccess extends ActionCreator = ActionCreator,
+  TFailure extends ActionCreator = ActionCreator,
+  TCancel extends ActionCreator | undefined = ActionCreator | undefined
+> = {
+  request: TRequest;
+  success: TSuccess;
+  failure: TFailure;
+  cancel?: TCancel;
+};
+
+export type AsyncEpicOutputAction<TAsyncAction extends AsyncActionCreatorMap> =
+  | ActionFromCreator<TAsyncAction['success']>
+  | ActionFromCreator<TAsyncAction['failure']>;
+
+export type CreateAsyncEpicOptions<
+  TAsyncAction extends AsyncActionCreatorMap
+> = {
+  mapError?: (
+    error: unknown,
+    action: ActionFromCreator<TAsyncAction['request']>
+  ) => FirstArgument<TAsyncAction['failure']>;
+};
+
+function callActionCreator<TActionCreator extends ActionCreator>(
+  actionCreator: TActionCreator,
+  payload: FirstArgument<TActionCreator>
+): ActionFromCreator<TActionCreator> {
+  return actionCreator(payload) as ActionFromCreator<TActionCreator>;
+}
+
+export function createAsyncEpic<
+  TAsyncAction extends AsyncActionCreatorMap,
+  TRootAction extends Action = Action,
+  TState = unknown,
+  TServices = unknown
+>(
+  asyncAction: TAsyncAction,
+  handler: (
+    action: ActionFromCreator<TAsyncAction['request']>,
+    state$: TState,
+    services: TServices
+  ) => ObservableInput<FirstArgument<TAsyncAction['success']>>,
+  options: CreateAsyncEpicOptions<TAsyncAction> = {}
+): (
+  action$: Observable<TRootAction>,
+  state$: TState,
+  services: TServices
+) => Observable<AsyncEpicOutputAction<TAsyncAction>> {
+  return (action$, state$, services) => {
+    const cancelAction = asyncAction.cancel;
+    const cancel$ =
+      cancelAction == null
+        ? undefined
+        : action$.pipe(filter(action => isActionOf(cancelAction, action)));
+
+    const toFailureAction = (
+      error: unknown,
+      requestAction: ActionFromCreator<TAsyncAction['request']>
+    ) =>
+      callActionCreator(
+        asyncAction.failure,
+        options.mapError
+          ? options.mapError(error, requestAction)
+          : (error as FirstArgument<TAsyncAction['failure']>)
+      ) as AsyncEpicOutputAction<TAsyncAction>;
+
+    return action$.pipe(
+      filter(action => isActionOf(asyncAction.request, action)),
+      switchMap(action => {
+        const requestAction = action as ActionFromCreator<
+          TAsyncAction['request']
+        >;
+        let input: ObservableInput<FirstArgument<TAsyncAction['success']>>;
+
+        try {
+          input = handler(requestAction, state$, services);
+        } catch (error) {
+          return of(toFailureAction(error, requestAction));
+        }
+
+        const response$ = from(input).pipe(
+          map(
+            payload =>
+              callActionCreator(
+                asyncAction.success,
+                payload
+              ) as AsyncEpicOutputAction<TAsyncAction>
+          ),
+          catchError(error => of(toFailureAction(error, requestAction)))
+        );
+
+        return cancel$ == null ? response$ : response$.pipe(takeUntil(cancel$));
+      })
+    );
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { action } from './action';
 export { createAction } from './create-action';
 export { createCustomAction } from './create-custom-action';
 export { createAsyncAction } from './create-async-action';
+export { createAsyncEpic } from './create-async-epic';
 export { createReducer } from './create-reducer';
 
 // action-helpers
@@ -39,6 +40,12 @@ export {
   ActionCreatorBuilder,
   AsyncActionCreatorBuilder,
 } from './type-helpers';
+
+export {
+  AsyncActionCreatorMap,
+  AsyncEpicOutputAction,
+  CreateAsyncEpicOptions,
+} from './create-async-epic';
 
 // deprecated
 export { default as deprecated } from './deprecated';


### PR DESCRIPTION
## Summary
- Add a `createAsyncEpic` helper for request/success/failure async action flows.
- Handle request filtering, switch-style in-flight replacement, emitted/thrown errors, and optional cancel actions.
- Add runtime tests, dts-jest snapshots, README coverage, and the RxJS peer/dev dependency needed by redux-observable users.

## Validation
- `npm run test:update`
- `npm run ci-check`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`
- `git diff --check`

## IssueHunt
Fixes #162.

Payout method: IssueHunt platform withdrawal to GitHub user `@jamilahmadzai`.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#162: Add a generic redux-observable factory automatically handling async-actions - createAsyncEpic](https://oss.issuehunt.io/repos/110746954/issues/162)
---
</details>
<!-- /Issuehunt content-->